### PR TITLE
Enhance interface with dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,12 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>SIN TRABAS - Ayuda para la disfemia</title>
+    <script>tailwind.config = { darkMode: 'class' };</script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="style.css">
 </head>
-<body class="bg-blue-50 font-sans">
+<body class="bg-blue-50 font-sans dark:bg-gray-900 dark:text-gray-100">
     <!-- Header/Navigation -->
-    <header class="bg-blue-600 text-white shadow-md">
+    <header class="bg-blue-600 text-white shadow-md sticky top-0 z-50 dark:bg-gray-800">
         <div class="container mx-auto px-4 py-4 flex flex-col md:flex-row justify-between items-center">
             <div class="flex items-center mb-4 md:mb-0">
                 <div class="text-4xl mr-3">🗣️</div>
@@ -25,6 +26,9 @@
                     <li><button onclick="showSection('contact')" class="nav-link px-3 py-2 rounded-lg hover:bg-blue-700 transition">Contacto</button></li>
                 </ul>
             </nav>
+            <button id="theme-toggle" onclick="toggleDarkMode()" class="mt-4 md:mt-0 bg-blue-500 hover:bg-blue-700 text-white px-3 py-2 rounded-lg transition dark:bg-gray-600">
+                🌙
+            </button>
         </div>
     </header>
 

--- a/script.js
+++ b/script.js
@@ -1,3 +1,18 @@
+        // Theme toggle
+        function toggleDarkMode() {
+            document.documentElement.classList.toggle('dark');
+            const isDark = document.documentElement.classList.contains('dark');
+            localStorage.setItem('darkMode', isDark ? '1' : '0');
+            document.getElementById('theme-toggle').textContent = isDark ? '☀️' : '🌙';
+        }
+
+        document.addEventListener('DOMContentLoaded', () => {
+            if (localStorage.getItem('darkMode') === '1') {
+                document.documentElement.classList.add('dark');
+                document.getElementById('theme-toggle').textContent = '☀️';
+            }
+        });
+
         // Section navigation
         function showSection(sectionId) {
             // Hide all sections

--- a/style.css
+++ b/style.css
@@ -19,7 +19,7 @@
             background: #e2f3ff;
             border-radius: 0.4em;
         }
-        .speech-bubble:after {
+.speech-bubble:after {
             content: '';
             position: absolute;
             bottom: 0;
@@ -30,5 +30,17 @@
             border-top-color: #e2f3ff;
             border-bottom: 0;
             margin-left: -10px;
-            margin-bottom: -10px;
-        }
+    margin-bottom: -10px;
+}
+
+/* Dark mode overrides */
+.dark .bg-white { background-color: #1e293b !important; }
+.dark .bg-blue-50 { background-color: #1e293b !important; }
+.dark .bg-gray-50 { background-color: #1e293b !important; }
+.dark header { background-color: #1e40af !important; }
+.dark footer { background-color: #1e40af !important; }
+.dark input,
+.dark select,
+.dark textarea { background-color: #334155; color: #f1f5f9; border-color: #475569; }
+.dark .speech-bubble { background: #334155; }
+.dark .speech-bubble:after { border-top-color: #334155; }


### PR DESCRIPTION
## Summary
- configure Tailwind to use class-based dark mode
- add dark mode toggle button in the header
- implement toggle logic in `script.js`
- style elements for dark theme
- make header sticky at top

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686e24e0dfcc832d866e5ba36de81de2