### PR TITLE
Improve navigation and accessibility across pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,6 @@
 <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
 <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;500;600;700;800&amp;display=swap" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
-<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
 <script id="tailwind-config">
         tailwind.config = {
             darkMode: "class",
@@ -32,26 +31,22 @@
         body {
             font-family: 'Manrope', sans-serif;
             -webkit-tap-highlight-color: transparent;
+            min-height: max(884px, 100dvh);
         }
         .material-symbols-outlined {
             font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
         }
     </style>
-<style>
-    body {
-      min-height: max(884px, 100dvh);
-    }
-  </style>
   </head>
 <body class="bg-background-light dark:bg-background-dark text-[#111418] dark:text-gray-100">
 <!-- TopAppBar -->
 <nav class="sticky top-0 z-50 flex items-center bg-white/80 dark:bg-background-dark/80 backdrop-blur-md p-4 pb-2 justify-between border-b border-gray-100 dark:border-gray-800">
-<div class="text-[#111418] dark:text-white flex size-12 shrink-0 items-center justify-center cursor-pointer">
+<button aria-label="Abrir menú" class="text-[#111418] dark:text-white flex size-12 shrink-0 items-center justify-center cursor-pointer" type="button">
 <span class="material-symbols-outlined">menu</span>
-</div>
+</button>
 <h2 class="text-[#111418] dark:text-white text-lg font-bold leading-tight tracking-[-0.015em] flex-1 text-center">Disfemia</h2>
 <div class="flex w-12 items-center justify-end">
-<button class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-xl h-12 bg-transparent text-[#111418] dark:text-white gap-2 text-base font-bold leading-normal tracking-[0.015em] min-w-0 p-0">
+<button aria-label="Buscar" class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-xl h-12 bg-transparent text-[#111418] dark:text-white gap-2 text-base font-bold leading-normal tracking-[0.015em] min-w-0 p-0" type="button">
 <span class="material-symbols-outlined">search</span>
 </button>
 </div>
@@ -59,7 +54,7 @@
 <main class="max-w-md mx-auto pb-24">
 <!-- HeroSection -->
 <div class="@container px-4 pt-4">
-<div class="flex min-h-[360px] flex-col gap-6 bg-cover bg-center bg-no-repeat rounded-xl items-center justify-center p-6 shadow-sm" data-alt="Abstract calming blue and green waves background" style='background-image: linear-gradient(rgba(19, 127, 236, 0.6) 0%, rgba(19, 127, 236, 0.8) 100%), url("https://lh3.googleusercontent.com/aida-public/AB6AXuDeiGDkpt8HGO7cBEsb_YjoUAmur_5Gye4GIrCpIveluU4zK48oI7PZjEk9V-O5A_fs5T7dVvRpJ0BPj4S4iK65Ft1pXnp-dwqvqf2zmKpzG_SfpfiM3AJdTZplWQxPLBJHSJlGStvIkIf3thOZkXvvGvibZwnmRa1Nes_jKk7CnjRgBb2FpukQkTIH0Y_PrT6hiAelMgS0TFqTpw7sYgmYrrNB0lJhu_cVS2OaDHdomFdeUs_mkurp4rWE_Z9MaiiKFIvVW9Wx7Kw");'>
+<div class="flex min-h-[360px] flex-col gap-6 bg-cover bg-center bg-no-repeat rounded-xl items-center justify-center p-6 shadow-sm" style='background-image: linear-gradient(rgba(19, 127, 236, 0.6) 0%, rgba(19, 127, 236, 0.8) 100%), url("https://lh3.googleusercontent.com/aida-public/AB6AXuDeiGDkpt8HGO7cBEsb_YjoUAmur_5Gye4GIrCpIveluU4zK48oI7PZjEk9V-O5A_fs5T7dVvRpJ0BPj4S4iK65Ft1pXnp-dwqvqf2zmKpzG_SfpfiM3AJdTZplWQxPLBJHSJlGStvIkIf3thOZkXvvGvibZwnmRa1Nes_jKk7CnjRgBb2FpukQkTIH0Y_PrT6hiAelMgS0TFqTpw7sYgmYrrNB0lJhu_cVS2OaDHdomFdeUs_mkurp4rWE_Z9MaiiKFIvVW9Wx7Kw");'>
 <div class="flex flex-col gap-2 text-center">
 <h1 class="text-white text-3xl font-black leading-tight tracking-[-0.033em] @[480px]:text-4xl">
                         Entendiendo la Disfemia
@@ -68,7 +63,7 @@
                         Un espacio seguro para aprender, crecer y mejorar tu comunicación diaria.
                     </p>
 </div>
-<button class="flex min-w-[140px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-12 px-6 bg-white text-primary text-sm font-bold leading-normal tracking-[0.015em] shadow-lg active:scale-95 transition-transform">
+<button class="flex min-w-[140px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-12 px-6 bg-white text-primary text-sm font-bold leading-normal tracking-[0.015em] shadow-lg active:scale-95 transition-transform" type="button">
 <span class="truncate">Comenzar guía</span>
 </button>
 </div>
@@ -160,29 +155,39 @@
 <div class="bg-primary p-6 rounded-2xl flex flex-col gap-4 text-white">
 <h4 class="text-xl font-bold">¿Necesitas ayuda profesional?</h4>
 <p class="text-white/80 text-sm">Contamos con una red de logopedas especializados listos para acompañarte.</p>
-<button class="w-full bg-white text-primary font-bold py-3 rounded-xl shadow-md active:bg-gray-50">
+<button class="w-full bg-white text-primary font-bold py-3 rounded-xl shadow-md active:bg-gray-50" type="button">
                     Consultar un experto
                 </button>
 </div>
 </div>
+<nav class="px-4 pb-6">
+<div class="flex flex-wrap gap-3 text-xs font-bold uppercase tracking-wide text-gray-500">
+<a aria-current="page" class="text-primary" href="index.html">Inicio</a>
+<a class="hover:text-primary transition-colors" href="index1.html">Shadowing</a>
+<a class="hover:text-primary transition-colors" href="index2.html">Inicio suave</a>
+<a class="hover:text-primary transition-colors" href="index3.html">Prolongación</a>
+<a class="hover:text-primary transition-colors" href="index4.html">Panel</a>
+<a class="hover:text-primary transition-colors" href="index5.html">Paciente</a>
+</div>
+</nav>
 </main>
 <!-- iOS style Bottom Navigation Tab Bar (Simulated) -->
 <div class="fixed bottom-0 left-0 right-0 bg-white/90 dark:bg-background-dark/90 backdrop-blur-md border-t border-gray-100 dark:border-gray-800 flex justify-around items-center h-20 pb-4 px-6 z-50">
-<div class="flex flex-col items-center text-primary">
+<a aria-current="page" class="flex flex-col items-center text-primary" href="index.html">
 <span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 1;">home</span>
 <span class="text-[10px] font-bold mt-1">Inicio</span>
-</div>
-<div class="flex flex-col items-center text-gray-400">
+</a>
+<a class="flex flex-col items-center text-gray-400 hover:text-primary transition-colors" href="index1.html">
 <span class="material-symbols-outlined">school</span>
 <span class="text-[10px] font-medium mt-1">Lecciones</span>
-</div>
-<div class="flex flex-col items-center text-gray-400">
+</a>
+<a class="flex flex-col items-center text-gray-400 hover:text-primary transition-colors" href="index2.html">
 <span class="material-symbols-outlined">fitness_center</span>
 <span class="text-[10px] font-medium mt-1">Ejercicios</span>
-</div>
-<div class="flex flex-col items-center text-gray-400">
+</a>
+<a class="flex flex-col items-center text-gray-400 hover:text-primary transition-colors" href="index5.html">
 <span class="material-symbols-outlined">person</span>
 <span class="text-[10px] font-medium mt-1">Perfil</span>
-</div>
+</a>
 </div>
 </body></html>

--- a/index1.html
+++ b/index1.html
@@ -7,7 +7,6 @@
 <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@200..800&amp;display=swap" rel="stylesheet"/>
-<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
 <script id="tailwind-config">
         tailwind.config = {
             darkMode: "class",
@@ -32,28 +31,25 @@
         }
         body {
             font-family: 'Manrope', sans-serif;
+            min-height: max(884px, 100dvh);
         }
     </style>
-<style>
-    body {
-      min-height: max(884px, 100dvh);
-    }
-  </style>
   </head>
-<body class="bg-background-light dark:bg-background-dark min-h-screen">
+<body class="bg-background-light dark:bg-background-dark min-h-screen text-[#111418] dark:text-white">
 <div class="relative flex h-auto min-h-screen w-full max-w-[430px] mx-auto flex-col bg-background-light dark:bg-background-dark overflow-x-hidden shadow-2xl">
 <!-- TopAppBar -->
 <div class="flex items-center bg-white dark:bg-background-dark p-4 pb-2 justify-between sticky top-0 z-10 border-b border-gray-100 dark:border-gray-800">
-<div class="text-primary flex size-12 shrink-0 items-center justify-start cursor-pointer">
+<a aria-label="Volver al inicio" class="text-primary flex size-12 shrink-0 items-center justify-start cursor-pointer" href="index.html">
 <span class="material-symbols-outlined text-2xl">arrow_back_ios</span>
-</div>
+</a>
 <h2 class="text-[#111418] dark:text-white text-lg font-bold leading-tight tracking-[-0.015em] flex-1 text-center">Técnica de Seguimiento</h2>
 <div class="flex w-12 items-center justify-end">
-<button class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-xl h-12 bg-transparent text-primary gap-2 text-base font-bold leading-normal tracking-[0.015em] min-w-0 p-0">
+<button aria-label="Información de la técnica" class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-xl h-12 bg-transparent text-primary gap-2 text-base font-bold leading-normal tracking-[0.015em] min-w-0 p-0" type="button">
 <span class="material-symbols-outlined text-2xl">info</span>
 </button>
 </div>
 </div>
+<main class="flex flex-1 flex-col">
 <!-- HeadlineText -->
 <div class="px-4">
 <h3 class="text-[#111418] dark:text-white tracking-light text-2xl font-bold leading-tight pt-6">Reto Diario</h3>
@@ -64,7 +60,7 @@
 <div class="flex flex-col items-stretch justify-start rounded-xl shadow-[0_4px_12px_rgba(0,0,0,0.05)] bg-white dark:bg-gray-900 border border-gray-100 dark:border-gray-800">
 <div class="w-full bg-primary/10 flex items-center justify-center aspect-[16/9] rounded-t-xl relative overflow-hidden">
 <!-- Abstract Background Pattern -->
-<div class="absolute inset-0 opacity-20" data-alt="Abstract blue wave patterns representing sound waves">
+<div class="absolute inset-0 opacity-20" aria-hidden="true">
 <div class="absolute inset-0 bg-gradient-to-br from-primary via-transparent to-primary/30"></div>
 </div>
 <span class="material-symbols-outlined text-primary text-6xl relative z-10">graphic_eq</span>
@@ -72,14 +68,14 @@
 <div class="flex w-full min-w-72 grow flex-col items-stretch justify-center gap-2 p-5">
 <div class="flex justify-between items-start">
 <p class="text-[#111418] dark:text-white text-lg font-bold leading-tight tracking-[-0.015em]">Fragmento de hoy</p>
-<span class="material-symbols-outlined text-primary text-xl">refresh</span>
+<span aria-hidden="true" class="material-symbols-outlined text-primary text-xl">refresh</span>
 </div>
 <p class="text-[#617589] dark:text-gray-300 text-base font-medium leading-relaxed italic border-l-4 border-primary/30 pl-3 my-2">
                         "El susurro del viento entre los pinos altos crea una melodía tranquila que relaja el alma."
                     </p>
 <div class="flex items-center gap-3 justify-between mt-2">
 <p class="text-[#617589] dark:text-gray-400 text-xs font-normal">Nivel: Principiante • 8 seg</p>
-<button class="flex min-w-[100px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-9 px-4 bg-primary text-white text-sm font-bold leading-normal shadow-md shadow-primary/20">
+<button class="flex min-w-[100px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-9 px-4 bg-primary text-white text-sm font-bold leading-normal shadow-md shadow-primary/20" type="button">
 <span class="truncate">Nuevo Reto</span>
 </button>
 </div>
@@ -139,20 +135,31 @@
 <div class="w-1.5 h-10 bg-gray-200 dark:bg-gray-700 rounded-full"></div>
 </div>
 <div class="flex items-center justify-center gap-8 w-full">
-<button class="flex items-center justify-center size-14 rounded-full bg-background-light dark:bg-gray-800 text-[#111418] dark:text-white border border-gray-200 dark:border-gray-700">
+<button aria-label="Reproducir ejemplo" class="flex items-center justify-center size-14 rounded-full bg-background-light dark:bg-gray-800 text-[#111418] dark:text-white border border-gray-200 dark:border-gray-700" type="button">
 <span class="material-symbols-outlined text-2xl">play_arrow</span>
 </button>
-<button class="flex items-center justify-center size-20 rounded-full bg-primary text-white shadow-lg shadow-primary/30 ring-4 ring-primary/10">
+<button aria-label="Iniciar grabación" class="flex items-center justify-center size-20 rounded-full bg-primary text-white shadow-lg shadow-primary/30 ring-4 ring-primary/10" type="button">
 <span class="material-symbols-outlined text-4xl">mic</span>
 </button>
-<button class="flex items-center justify-center size-14 rounded-full bg-background-light dark:bg-gray-800 text-[#111418] dark:text-white border border-gray-200 dark:border-gray-700">
+<button aria-label="Ver historial" class="flex items-center justify-center size-14 rounded-full bg-background-light dark:bg-gray-800 text-[#111418] dark:text-white border border-gray-200 dark:border-gray-700" type="button">
 <span class="material-symbols-outlined text-2xl">history</span>
 </button>
 </div>
 <p class="text-primary font-bold text-sm tracking-widest uppercase">Pulsa para empezar</p>
 </div>
 </div>
+<nav class="mt-6 border-t border-gray-100 dark:border-gray-800 bg-white dark:bg-gray-900 px-4 py-3">
+<div class="flex justify-between text-[11px] font-bold uppercase tracking-wide">
+<a class="text-gray-500 hover:text-primary transition-colors" href="index.html">Inicio</a>
+<a aria-current="page" class="text-primary" href="index1.html">Shadowing</a>
+<a class="text-gray-500 hover:text-primary transition-colors" href="index2.html">Inicio suave</a>
+<a class="text-gray-500 hover:text-primary transition-colors" href="index3.html">Prolongación</a>
+<a class="text-gray-500 hover:text-primary transition-colors" href="index4.html">Panel</a>
+<a class="text-gray-500 hover:text-primary transition-colors" href="index5.html">Paciente</a>
+</div>
+</nav>
 <!-- Space for iOS Home Indicator -->
 <div class="h-6 bg-white dark:bg-gray-900"></div>
+</main>
 </div>
 </body></html>

--- a/index2.html
+++ b/index2.html
@@ -5,7 +5,6 @@
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
-<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
 <script id="tailwind-config">
         tailwind.config = {
             darkMode: "class",
@@ -30,17 +29,20 @@
     body {
       min-height: max(884px, 100dvh);
     }
+    .material-symbols-outlined {
+      font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+    }
   </style>
   </head>
 <body class="bg-background-light dark:bg-background-dark font-display text-[#111418] dark:text-white min-h-screen">
 <!-- Top Navigation Bar -->
 <div class="sticky top-0 z-50 flex items-center bg-white/80 dark:bg-background-dark/80 backdrop-blur-md p-4 pb-2 justify-between border-b border-gray-100 dark:border-gray-800">
-<div class="text-[#111418] dark:text-white flex size-12 shrink-0 items-center justify-start">
+<a aria-label="Volver al inicio" class="text-[#111418] dark:text-white flex size-12 shrink-0 items-center justify-start" href="index.html">
 <span class="material-symbols-outlined cursor-pointer">arrow_back_ios</span>
-</div>
+</a>
 <h2 class="text-[#111418] dark:text-white text-lg font-bold leading-tight tracking-[-0.015em] flex-1 text-center">Técnica: Inicio Suave</h2>
 <div class="flex w-12 items-center justify-end">
-<button class="flex cursor-pointer items-center justify-center rounded-xl h-12 bg-transparent text-[#111418] dark:text-white">
+<button aria-label="Ayuda" class="flex cursor-pointer items-center justify-center rounded-xl h-12 bg-transparent text-[#111418] dark:text-white" type="button">
 <span class="material-symbols-outlined">help_outline</span>
 </button>
 </div>
@@ -56,8 +58,8 @@
                     </span>
 </div>
 <!-- Waveform Placeholder -->
-<div class="w-full bg-slate-50 dark:bg-slate-800 aspect-[16/9] rounded-lg overflow-hidden relative border border-dashed border-gray-200 dark:border-gray-700 flex flex-col items-center justify-center" data-alt="Abstract smooth green and blue sine wave representation on a dark background">
-<div class="absolute inset-0 flex items-center justify-around px-8">
+<div class="w-full bg-slate-50 dark:bg-slate-800 aspect-[16/9] rounded-lg overflow-hidden relative border border-dashed border-gray-200 dark:border-gray-700 flex flex-col items-center justify-center">
+<div aria-hidden="true" class="absolute inset-0 flex items-center justify-around px-8">
 <div class="w-1 h-4 bg-accent-green/40 rounded-full"></div>
 <div class="w-1 h-8 bg-accent-green/60 rounded-full"></div>
 <div class="w-1 h-12 bg-accent-green/80 rounded-full"></div>
@@ -75,7 +77,7 @@
 </div>
 <!-- Sentence Generator Card -->
 <div class="px-4 mt-6">
-<div class="relative bg-primary overflow-hidden rounded-xl shadow-lg" data-alt="Deep blue gradient with subtle geometric patterns" style="background-image: linear-gradient(135deg, #137fec 0%, #0b5fb3 100%);">
+<div class="relative bg-primary overflow-hidden rounded-xl shadow-lg" style="background-image: linear-gradient(135deg, #137fec 0%, #0b5fb3 100%);">
 <div class="p-6">
 <div class="flex flex-col gap-2 mb-6">
 <span class="text-white/70 text-xs font-bold uppercase tracking-widest">Frase de Práctica</span>
@@ -92,7 +94,7 @@
 <span class="material-symbols-outlined text-white text-sm">auto_awesome</span>
 </div>
 </div>
-<button class="flex items-center gap-2 px-6 py-3 bg-white text-primary rounded-xl font-bold shadow-md active:scale-95 transition-transform">
+<button class="flex items-center gap-2 px-6 py-3 bg-white text-primary rounded-xl font-bold shadow-md active:scale-95 transition-transform" type="button">
 <span class="material-symbols-outlined text-sm">refresh</span>
 <span>Nueva Frase</span>
 </button>
@@ -126,15 +128,26 @@
 </div>
 </div>
 </div>
+</div>
+<nav class="mt-8 px-4">
+<div class="flex flex-wrap gap-3 text-xs font-bold uppercase tracking-wide text-gray-500">
+<a class="hover:text-primary transition-colors" href="index.html">Inicio</a>
+<a class="hover:text-primary transition-colors" href="index1.html">Shadowing</a>
+<a aria-current="page" class="text-primary" href="index2.html">Inicio suave</a>
+<a class="hover:text-primary transition-colors" href="index3.html">Prolongación</a>
+<a class="hover:text-primary transition-colors" href="index4.html">Panel</a>
+<a class="hover:text-primary transition-colors" href="index5.html">Paciente</a>
+</div>
+</nav>
 </main>
 <!-- Bottom Action Bar (Floating) -->
 <div class="fixed bottom-0 left-0 right-0 p-4 bg-white/90 dark:bg-background-dark/90 backdrop-blur-lg border-t border-gray-100 dark:border-gray-800">
 <div class="max-w-md mx-auto flex items-center gap-4">
-<button class="flex-1 bg-primary text-white font-bold py-4 rounded-xl flex items-center justify-center gap-2 shadow-lg shadow-primary/30">
+<button aria-label="Grabar intento" class="flex-1 bg-primary text-white font-bold py-4 rounded-xl flex items-center justify-center gap-2 shadow-lg shadow-primary/30" type="button">
 <span class="material-symbols-outlined">mic</span>
                 Grabar Intento
             </button>
-<button class="w-14 h-14 border-2 border-primary/20 flex items-center justify-center rounded-xl text-primary">
+<button aria-label="Ver analíticas" class="w-14 h-14 border-2 border-primary/20 flex items-center justify-center rounded-xl text-primary" type="button">
 <span class="material-symbols-outlined">analytics</span>
 </button>
 </div>

--- a/index3.html
+++ b/index3.html
@@ -6,7 +6,6 @@
 <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@200..800&amp;display=swap" rel="stylesheet"/>
-<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
 <script id="tailwind-config">
         tailwind.config = {
             darkMode: "class",
@@ -26,30 +25,25 @@
         }
     </script>
 <style>
-        body { font-family: 'Manrope', sans-serif; }
+        body { font-family: 'Manrope', sans-serif; min-height: max(884px, 100dvh); }
         .material-symbols-outlined {
             font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
         }
     </style>
-<style>
-    body {
-      min-height: max(884px, 100dvh);
-    }
-  </style>
   </head>
 <body class="bg-background-light dark:bg-background-dark min-h-screen flex flex-col transition-colors duration-300">
 <!-- Top Navigation Bar -->
 <header class="sticky top-0 z-50 bg-white/80 dark:bg-background-dark/80 backdrop-blur-md border-b border-gray-100 dark:border-gray-800">
 <div class="flex items-center p-4 justify-between max-w-md mx-auto">
-<div class="text-[#111418] dark:text-white flex size-12 shrink-0 items-center justify-start">
+<a aria-label="Volver al inicio" class="text-[#111418] dark:text-white flex size-12 shrink-0 items-center justify-start" href="index.html">
 <span class="material-symbols-outlined cursor-pointer">arrow_back_ios</span>
-</div>
+</a>
 <div class="flex flex-col items-center">
 <h2 class="text-[#111418] dark:text-white text-lg font-bold leading-tight tracking-tight">Técnica de Habla</h2>
 <span class="text-xs text-primary font-medium">Sesión 1: Prolongación</span>
 </div>
 <div class="flex w-12 items-center justify-end">
-<button class="flex items-center justify-center rounded-xl h-12 bg-transparent text-primary">
+<button aria-label="Ayuda" class="flex items-center justify-center rounded-xl h-12 bg-transparent text-primary" type="button">
 <span class="material-symbols-outlined">help</span>
 </button>
 </div>
@@ -119,7 +113,7 @@
 </div>
 <!-- Guidance Button -->
 <div class="mt-12 w-full">
-<button class="w-full flex items-center justify-center gap-2 rounded-xl h-14 bg-primary/10 hover:bg-primary/20 text-primary font-bold transition-colors">
+<button aria-label="Escuchar guía" class="w-full flex items-center justify-center gap-2 rounded-xl h-14 bg-primary/10 hover:bg-primary/20 text-primary font-bold transition-colors" type="button">
 <span class="material-symbols-outlined">volume_up</span>
 <span>Escuchar Guía</span>
 </button>
@@ -129,15 +123,15 @@
 <!-- Action Controls -->
 <div class="px-6 py-8 flex flex-col gap-4">
 <div class="flex gap-4">
-<button class="flex-1 flex flex-col items-center justify-center gap-1 rounded-xl h-24 bg-white dark:bg-gray-800 shadow-sm border border-gray-100 dark:border-gray-700 active:scale-95 transition-transform">
+<button aria-label="Cambiar palabra" class="flex-1 flex flex-col items-center justify-center gap-1 rounded-xl h-24 bg-white dark:bg-gray-800 shadow-sm border border-gray-100 dark:border-gray-700 active:scale-95 transition-transform" type="button">
 <span class="material-symbols-outlined text-gray-400">refresh</span>
 <span class="text-sm font-medium text-gray-600 dark:text-gray-300">Cambiar</span>
 </button>
-<button class="flex-[2] flex items-center justify-center gap-3 rounded-xl h-24 bg-primary text-white shadow-lg shadow-primary/25 active:scale-95 transition-transform">
+<button aria-label="Iniciar sesión" class="flex-[2] flex items-center justify-center gap-3 rounded-xl h-24 bg-primary text-white shadow-lg shadow-primary/25 active:scale-95 transition-transform" type="button">
 <span class="material-symbols-outlined text-3xl">play_circle</span>
 <span class="text-lg font-bold">Iniciar</span>
 </button>
-<button class="flex-1 flex flex-col items-center justify-center gap-1 rounded-xl h-24 bg-white dark:bg-gray-800 shadow-sm border border-gray-100 dark:border-gray-700 active:scale-95 transition-transform">
+<button aria-label="Marcar como logrado" class="flex-1 flex flex-col items-center justify-center gap-1 rounded-xl h-24 bg-white dark:bg-gray-800 shadow-sm border border-gray-100 dark:border-gray-700 active:scale-95 transition-transform" type="button">
 <span class="material-symbols-outlined text-gray-400">check_circle</span>
 <span class="text-sm font-medium text-gray-600 dark:text-gray-300">Logrado</span>
 </button>
@@ -146,26 +140,36 @@
                 Consejo: Mantén los hombros relajados y exhala suavemente.
             </p>
 </div>
+<nav class="px-6 pb-6">
+<div class="flex flex-wrap gap-3 text-xs font-bold uppercase tracking-wide text-gray-500 justify-center">
+<a class="hover:text-primary transition-colors" href="index.html">Inicio</a>
+<a class="hover:text-primary transition-colors" href="index1.html">Shadowing</a>
+<a class="hover:text-primary transition-colors" href="index2.html">Inicio suave</a>
+<a aria-current="page" class="text-primary" href="index3.html">Prolongación</a>
+<a class="hover:text-primary transition-colors" href="index4.html">Panel</a>
+<a class="hover:text-primary transition-colors" href="index5.html">Paciente</a>
+</div>
+</nav>
 </main>
 <!-- Bottom Navigation Bar (iOS Style) -->
 <nav class="pb-8 pt-2 px-6 bg-white dark:bg-background-dark border-t border-gray-100 dark:border-gray-800">
 <div class="flex justify-around items-center max-w-md mx-auto">
-<div class="flex flex-col items-center gap-1 text-primary">
+<a aria-current="page" class="flex flex-col items-center gap-1 text-primary" href="index3.html">
 <span class="material-symbols-outlined">exercise</span>
 <span class="text-[10px] font-bold">Práctica</span>
-</div>
-<div class="flex flex-col items-center gap-1 text-gray-400">
+</a>
+<a class="flex flex-col items-center gap-1 text-gray-400 hover:text-primary transition-colors" href="index4.html">
 <span class="material-symbols-outlined">analytics</span>
 <span class="text-[10px] font-medium">Progreso</span>
-</div>
-<div class="flex flex-col items-center gap-1 text-gray-400">
+</a>
+<a class="flex flex-col items-center gap-1 text-gray-400 hover:text-primary transition-colors" href="index1.html">
 <span class="material-symbols-outlined">school</span>
 <span class="text-[10px] font-medium">Cursos</span>
-</div>
-<div class="flex flex-col items-center gap-1 text-gray-400">
+</a>
+<a class="flex flex-col items-center gap-1 text-gray-400 hover:text-primary transition-colors" href="index5.html">
 <span class="material-symbols-outlined">person</span>
 <span class="text-[10px] font-medium">Perfil</span>
-</div>
+</a>
 </div>
 </nav>
 </body></html>

--- a/index4.html
+++ b/index4.html
@@ -10,16 +10,15 @@
 <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@200..800&amp;display=swap" rel="stylesheet"/>
 <!-- Material Symbols Outlined -->
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
-<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
 <script id="tailwind-config">
         tailwind.config = {
             darkMode: "class",
             theme: {
                 extend: {
                     colors: {
-                        "primary": "#2bdeee",
-                        "background-light": "#f6f8f8",
-                        "background-dark": "#102022",
+                        "primary": "#137fec",
+                        "background-light": "#f6f7f8",
+                        "background-dark": "#101922",
                     },
                     fontFamily: {
                         "display": ["Manrope", "sans-serif"]
@@ -35,40 +34,44 @@
         }
         body {
             font-family: 'Manrope', sans-serif;
+            min-height: max(884px, 100dvh);
         }
     </style>
-<style>
-    body {
-      min-height: max(884px, 100dvh);
-    }
-  </style>
   </head>
-<body class="bg-background-light dark:bg-background-dark text-[#111718] dark:text-white min-h-screen">
+<body class="bg-background-light dark:bg-background-dark text-[#111418] dark:text-white min-h-screen">
 <!-- Navigation Drawer (Overlay - Hidden by default in a real app, here shown as part of the structure) -->
 <!-- For this static UI, we'll keep the Drawer available or use it as a side menu if wide, but on mobile it's an overlay -->
-<div class="fixed inset-0 z-50 hidden" id="side-drawer">
-<div class="absolute inset-0 bg-[#141414]/40 backdrop-blur-sm" onclick="document.getElementById('side-drawer').classList.add('hidden')"></div>
+<div aria-hidden="true" class="fixed inset-0 z-50 hidden" id="side-drawer" role="dialog" aria-modal="true">
+<button aria-label="Cerrar menú" class="absolute inset-0 bg-[#141414]/40 backdrop-blur-sm" data-drawer-close type="button"></button>
 <div class="relative flex h-full w-10/12 flex-col bg-white dark:bg-background-dark p-4 shadow-2xl">
 <div class="flex items-center justify-between px-4 pb-6 pt-4 border-b border-[#dbe5e6] dark:border-white/10">
 <p class="text-[22px] font-bold leading-tight tracking-[-0.015em]">Dr. García</p>
-<span class="material-symbols-outlined cursor-pointer" onclick="document.getElementById('side-drawer').classList.add('hidden')">close</span>
+<button aria-label="Cerrar menú" class="material-symbols-outlined cursor-pointer" data-drawer-close type="button">close</button>
 </div>
 <ul class="flex flex-col gap-2 mt-6">
-<li class="flex h-12 items-center gap-4 rounded-xl px-4 bg-primary/20 text-primary">
+<li>
+<a class="flex h-12 items-center gap-4 rounded-xl px-4 bg-primary/20 text-primary" href="index5.html">
 <span class="material-symbols-outlined">group</span>
 <p class="text-base font-bold leading-tight truncate">Pacientes</p>
+</a>
 </li>
-<li class="flex h-12 items-center gap-4 rounded-xl px-4 hover:bg-primary/10 transition-colors">
+<li>
+<a class="flex h-12 items-center gap-4 rounded-xl px-4 hover:bg-primary/10 transition-colors" href="index1.html">
 <span class="material-symbols-outlined">description</span>
 <p class="text-base font-bold leading-tight truncate">Informes</p>
+</a>
 </li>
-<li class="flex h-12 items-center gap-4 rounded-xl px-4 hover:bg-primary/10 transition-colors">
+<li>
+<a class="flex h-12 items-center gap-4 rounded-xl px-4 hover:bg-primary/10 transition-colors" href="index3.html">
 <span class="material-symbols-outlined">folder_open</span>
 <p class="text-base font-bold leading-tight truncate">Materiales</p>
+</a>
 </li>
-<li class="mt-auto flex h-12 items-center gap-4 rounded-xl px-4 text-red-500">
+<li class="mt-auto">
+<a class="flex h-12 items-center gap-4 rounded-xl px-4 text-red-500" href="index.html">
 <span class="material-symbols-outlined">logout</span>
 <p class="text-base font-bold leading-tight truncate">Cerrar Sesión</p>
+</a>
 </li>
 </ul>
 </div>
@@ -78,13 +81,13 @@
 <!-- Top App Bar -->
 <header class="sticky top-0 z-40 flex items-center bg-background-light dark:bg-background-dark px-4 py-4 justify-between border-b border-[#dbe5e6] dark:border-white/10">
 <div class="flex items-center gap-3">
-<button class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-white dark:bg-white/5 border border-[#dbe5e6] dark:border-white/10" onclick="document.getElementById('side-drawer').classList.remove('hidden')">
+<button aria-controls="side-drawer" aria-expanded="false" aria-label="Abrir menú" class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-white dark:bg-white/5 border border-[#dbe5e6] dark:border-white/10" id="drawer-open" type="button">
 <span class="material-symbols-outlined">menu</span>
 </button>
 <h2 class="text-lg font-bold leading-tight tracking-[-0.015em]">Vista General</h2>
 </div>
 <div class="flex gap-2">
-<button class="flex size-10 items-center justify-center rounded-xl bg-white dark:bg-white/5 border border-[#dbe5e6] dark:border-white/10 relative">
+<button aria-label="Notificaciones" class="flex size-10 items-center justify-center rounded-xl bg-white dark:bg-white/5 border border-[#dbe5e6] dark:border-white/10 relative" type="button">
 <span class="material-symbols-outlined">notifications</span>
 <span class="absolute top-2 right-2 size-2 bg-red-500 rounded-full border-2 border-white dark:border-background-dark"></span>
 </button>
@@ -135,11 +138,11 @@
 <div class="flex min-h-[160px] flex-col gap-6 py-4">
 <svg fill="none" height="120" preserveaspectratio="none" viewbox="0 0 478 150" width="100%" xmlns="http://www.w3.org/2000/svg">
 <path d="M0 109C18.1538 109 18.1538 21 36.3077 21C54.4615 21 54.4615 41 72.6154 41C90.7692 41 90.7692 93 108.923 93C127.077 93 127.077 33 145.231 33C163.385 33 163.385 101 181.538 101C199.692 101 199.692 61 217.846 61C236 61 236 45 254.154 45C272.308 45 272.308 121 290.462 121C308.615 121 308.615 149 326.769 149C344.923 149 344.923 11 363.077 11C381.231 11 381.231 81 399.385 81C417.538 81 417.538 129 435.692 129C453.846 129 453.846 25 472 25V149H0V109Z" fill="url(#chartGradient)"></path>
-<path d="M0 109C18.1538 109 18.1538 21 36.3077 21C54.4615 21 54.4615 41 72.6154 41C90.7692 41 90.7692 93 108.923 93C127.077 93 127.077 33 145.231 33C163.385 33 163.385 101 181.538 101C199.692 101 199.692 61 217.846 61C236 61 236 45 254.154 45C272.308 45 272.308 121 290.462 121C308.615 121 308.615 149 326.769 149C344.923 149 344.923 11 363.077 11C381.231 11 381.231 81 399.385 81C417.538 81 417.538 129 435.692 129C453.846 129 453.846 25 472 25" stroke="#2bdeee" stroke-linecap="round" stroke-width="3"></path>
+<path d="M0 109C18.1538 109 18.1538 21 36.3077 21C54.4615 21 54.4615 41 72.6154 41C90.7692 41 90.7692 93 108.923 93C127.077 93 127.077 33 145.231 33C163.385 33 163.385 101 181.538 101C199.692 101 199.692 61 217.846 61C236 61 236 45 254.154 45C272.308 45 272.308 121 290.462 121C308.615 121 308.615 149 326.769 149C344.923 149 344.923 11 363.077 11C381.231 11 381.231 81 399.385 81C417.538 81 417.538 129 435.692 129C453.846 129 453.846 25 472 25" stroke="#137fec" stroke-linecap="round" stroke-width="3"></path>
 <defs>
 <lineargradient gradientunits="userSpaceOnUse" id="chartGradient" x1="236" x2="236" y1="1" y2="149">
-<stop stop-color="#2bdeee" stop-opacity="0.3"></stop>
-<stop offset="1" stop-color="#2bdeee" stop-opacity="0"></stop>
+<stop stop-color="#137fec" stop-opacity="0.3"></stop>
+<stop offset="1" stop-color="#137fec" stop-opacity="0"></stop>
 </lineargradient>
 </defs>
 </svg>
@@ -165,7 +168,7 @@
 <!-- Patient Card 1 -->
 <div class="flex items-center gap-4 rounded-2xl bg-white dark:bg-white/5 p-4 border border-[#dbe5e6] dark:border-white/10">
 <div class="size-12 rounded-full overflow-hidden bg-gray-100 shrink-0">
-<img class="size-full object-cover" data-alt="Portrait of a young boy smiling" src="https://lh3.googleusercontent.com/aida-public/AB6AXuBhYmKF4ADUc-zHx4B95WLbjO369xqhZrKdnELEypsf__xHfMTq3d1dRqzRGxz07Kohy13_yUOa7r97lg6Z2YEtbs4_kO6_YaVzaMVtaOxuxdaunppfsgbnfbm1Gu3ZuTh9sgYa1vKB9IKQTzfSCbsBSXsrOFu2hPl_tshOutjS7svCJQvIoT9EZI_u2_v1WTgsQd6CxoO7nf4BsNEyi3C4VJB5nrOU01KLP-Zx5tlM-a_M9HwHR3uLZNASGKDtF5OXbVOQfnDlbeE"/>
+<img alt="Lucas Méndez sonriendo" class="size-full object-cover" src="https://lh3.googleusercontent.com/aida-public/AB6AXuBhYmKF4ADUc-zHx4B95WLbjO369xqhZrKdnELEypsf__xHfMTq3d1dRqzRGxz07Kohy13_yUOa7r97lg6Z2YEtbs4_kO6_YaVzaMVtaOxuxdaunppfsgbnfbm1Gu3ZuTh9sgYa1vKB9IKQTzfSCbsBSXsrOFu2hPl_tshOutjS7svCJQvIoT9EZI_u2_v1WTgsQd6CxoO7nf4BsNEyi3C4VJB5nrOU01KLP-Zx5tlM-a_M9HwHR3uLZNASGKDtF5OXbVOQfnDlbeE"/>
 </div>
 <div class="flex-1 min-w-0">
 <h3 class="font-bold text-base truncate">Lucas Méndez</h3>
@@ -182,7 +185,7 @@
 <!-- Patient Card 2 -->
 <div class="flex items-center gap-4 rounded-2xl bg-white dark:bg-white/5 p-4 border border-[#dbe5e6] dark:border-white/10">
 <div class="size-12 rounded-full overflow-hidden bg-gray-100 shrink-0">
-<img class="size-full object-cover" data-alt="Portrait of a teenage girl" src="https://lh3.googleusercontent.com/aida-public/AB6AXuCE030pGKVmQohkyKx9bBGQXR0nuwy0n7LNGbClITZ0MB4opmUGxhvS3nq_2VCBOIqYPzA8FRsTI38qoAOmv8I65MzL6fMun8i2aON5Y2BxQ4DBJYBE6lV55P3TkWNHvJcOBEotpywCOvCMJnWuiQQ7yVvFY2UyqaHbMt0BZRpBNVAe6gbWlyKotoiNhMBTt6u0BtBC5w_4vDH-SD13JAH3wlLg2rvRGbtPQCaKS81_Ntk4cjugyVw78xt7_2VglCDyrygXN8fKclA"/>
+<img alt="Sofía Rodríguez" class="size-full object-cover" src="https://lh3.googleusercontent.com/aida-public/AB6AXuCE030pGKVmQohkyKx9bBGQXR0nuwy0n7LNGbClITZ0MB4opmUGxhvS3nq_2VCBOIqYPzA8FRsTI38qoAOmv8I65MzL6fMun8i2aON5Y2BxQ4DBJYBE6lV55P3TkWNHvJcOBEotpywCOvCMJnWuiQQ7yVvFY2UyqaHbMt0BZRpBNVAe6gbWlyKotoiNhMBTt6u0BtBC5w_4vDH-SD13JAH3wlLg2rvRGbtPQCaKS81_Ntk4cjugyVw78xt7_2VglCDyrygXN8fKclA"/>
 </div>
 <div class="flex-1 min-w-0">
 <h3 class="font-bold text-base truncate">Sofía Rodríguez</h3>
@@ -199,7 +202,7 @@
 <!-- Patient Card 3 -->
 <div class="flex items-center gap-4 rounded-2xl bg-white dark:bg-white/5 p-4 border border-[#dbe5e6] dark:border-white/10">
 <div class="size-12 rounded-full overflow-hidden bg-gray-100 shrink-0">
-<img class="size-full object-cover" data-alt="Portrait of a young woman" src="https://lh3.googleusercontent.com/aida-public/AB6AXuB-FwVIiGhBem5f926EP1VmgyENbIMfGvvv8MsmmnPJ6VmACVPlkLCPu4qm1iQxO-4p4YO6ice3TPWTR8FvSFxV70RgXeDY5nNKyJZtz6HMWldqIDkBr0l2Eu9Var4vu52NVYYtEFu2ASvhP43liN46M5ZAkUAJUEbyoH6EusLp--DaBgNM4A85Z20x1FEhWdl5FDyGEVJFrTotGl8L5pI2WPKbinBbejo14vXtJ5r2n09VwREg8R6o0xoS3ZXnhbm8sTGm3vlgCTY"/>
+<img alt="Elena Sanz" class="size-full object-cover" src="https://lh3.googleusercontent.com/aida-public/AB6AXuB-FwVIiGhBem5f926EP1VmgyENbIMfGvvv8MsmmnPJ6VmACVPlkLCPu4qm1iQxO-4p4YO6ice3TPWTR8FvSFxV70RgXeDY5nNKyJZtz6HMWldqIDkBr0l2Eu9Var4vu52NVYYtEFu2ASvhP43liN46M5ZAkUAJUEbyoH6EusLp--DaBgNM4A85Z20x1FEhWdl5FDyGEVJFrTotGl8L5pI2WPKbinBbejo14vXtJ5r2n09VwREg8R6o0xoS3ZXnhbm8sTGm3vlgCTY"/>
 </div>
 <div class="flex-1 min-w-0">
 <h3 class="font-bold text-base truncate">Elena Sanz</h3>
@@ -215,34 +218,69 @@
 </div>
 </div>
 </section>
+<nav class="px-4 pb-8">
+<div class="flex flex-wrap gap-3 text-xs font-bold uppercase tracking-wide text-[#618689] dark:text-gray-400">
+<a class="hover:text-primary transition-colors" href="index.html">Inicio</a>
+<a class="hover:text-primary transition-colors" href="index1.html">Shadowing</a>
+<a class="hover:text-primary transition-colors" href="index2.html">Inicio suave</a>
+<a class="hover:text-primary transition-colors" href="index3.html">Prolongación</a>
+<a aria-current="page" class="text-primary" href="index4.html">Panel</a>
+<a class="hover:text-primary transition-colors" href="index5.html">Paciente</a>
+</div>
+</nav>
 </main>
 <!-- Bottom Navigation Bar (iOS Style) -->
 <nav class="fixed bottom-0 left-0 right-0 z-50 bg-white/80 dark:bg-background-dark/80 backdrop-blur-lg border-t border-[#dbe5e6] dark:border-white/10 pb-8 pt-3 px-6">
 <div class="flex justify-between items-center max-w-md mx-auto">
-<div class="flex flex-col items-center gap-1 text-primary">
+<a aria-current="page" class="flex flex-col items-center gap-1 text-primary" href="index4.html">
 <span class="material-symbols-outlined font-bold">home</span>
 <span class="text-[10px] font-bold">Inicio</span>
-</div>
-<div class="flex flex-col items-center gap-1 text-[#618689] dark:text-gray-400">
+</a>
+<a class="flex flex-col items-center gap-1 text-[#618689] dark:text-gray-400 hover:text-primary transition-colors" href="index5.html">
 <span class="material-symbols-outlined">group</span>
 <span class="text-[10px] font-bold">Pacientes</span>
-</div>
+</a>
 <!-- Floating Action Button in Nav? No, keep it separate for iOS. But we can center one. -->
-<div class="flex flex-col items-center -mt-8">
-<div class="size-14 rounded-full bg-primary flex items-center justify-center text-white shadow-lg shadow-primary/40 mb-1">
+<a class="flex flex-col items-center -mt-8" href="index.html">
+<div class="size-14 rounded-full bg-primary flex items-center justify-center text-white shadow-lg shadow-primary/40 mb-1" role="presentation">
 <span class="material-symbols-outlined text-2xl">add</span>
 </div>
 <span class="text-[10px] font-bold text-primary">Nuevo</span>
-</div>
-<div class="flex flex-col items-center gap-1 text-[#618689] dark:text-gray-400">
+</a>
+<a class="flex flex-col items-center gap-1 text-[#618689] dark:text-gray-400 hover:text-primary transition-colors" href="index1.html">
 <span class="material-symbols-outlined">description</span>
 <span class="text-[10px] font-bold">Informes</span>
-</div>
-<div class="flex flex-col items-center gap-1 text-[#618689] dark:text-gray-400">
+</a>
+<a class="flex flex-col items-center gap-1 text-[#618689] dark:text-gray-400 hover:text-primary transition-colors" href="index2.html">
 <span class="material-symbols-outlined">settings</span>
 <span class="text-[10px] font-bold">Ajustes</span>
-</div>
+</a>
 </div>
 </nav>
 </div>
+<script>
+        const drawer = document.getElementById("side-drawer");
+        const openButton = document.getElementById("drawer-open");
+        const closeButtons = drawer.querySelectorAll("[data-drawer-close]");
+
+        const openDrawer = () => {
+            drawer.classList.remove("hidden");
+            drawer.setAttribute("aria-hidden", "false");
+            openButton.setAttribute("aria-expanded", "true");
+        };
+
+        const closeDrawer = () => {
+            drawer.classList.add("hidden");
+            drawer.setAttribute("aria-hidden", "true");
+            openButton.setAttribute("aria-expanded", "false");
+        };
+
+        openButton.addEventListener("click", openDrawer);
+        closeButtons.forEach((button) => button.addEventListener("click", closeDrawer));
+        document.addEventListener("keydown", (event) => {
+            if (event.key === "Escape" && drawer.getAttribute("aria-hidden") === "false") {
+                closeDrawer();
+            }
+        });
+    </script>
 </body></html>

--- a/index5.html
+++ b/index5.html
@@ -7,7 +7,6 @@
 <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@200;300;400;500;600;700;800&amp;display=swap" rel="stylesheet"/>
-<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
 <script id="tailwind-config">
         tailwind.config = {
             darkMode: "class",
@@ -34,27 +33,23 @@
 <style>
         body {
             font-family: 'Manrope', sans-serif;
+            min-height: max(884px, 100dvh);
         }
         .material-symbols-outlined {
             font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
         }
     </style>
-<style>
-    body {
-      min-height: max(884px, 100dvh);
-    }
-  </style>
   </head>
 <body class="bg-background-light dark:bg-background-dark text-[#111418] dark:text-white min-h-screen">
 <div class="max-w-[480px] mx-auto bg-white dark:bg-[#1a242f] min-h-screen shadow-sm">
 <!-- TopAppBar -->
 <div class="flex items-center bg-white dark:bg-[#1a242f] p-4 pb-2 justify-between sticky top-0 z-10 border-b border-gray-100 dark:border-gray-800">
-<div class="text-[#111418] dark:text-white flex size-12 shrink-0 items-center cursor-pointer">
+<a aria-label="Volver al inicio" class="text-[#111418] dark:text-white flex size-12 shrink-0 items-center cursor-pointer" href="index.html">
 <span class="material-symbols-outlined">arrow_back_ios</span>
-</div>
+</a>
 <h2 class="text-[#111418] dark:text-white text-lg font-bold leading-tight tracking-[-0.015em] flex-1 text-center">Expediente Clínico</h2>
 <div class="flex w-12 items-center justify-end">
-<button class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-xl h-12 bg-transparent text-primary gap-2 text-base font-bold leading-normal tracking-[0.015em] min-w-0 p-0">
+<button aria-label="Abrir chat" class="flex max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-xl h-12 bg-transparent text-primary gap-2 text-base font-bold leading-normal tracking-[0.015em] min-w-0 p-0" type="button">
 <span class="material-symbols-outlined">chat_bubble</span>
 </button>
 </div>
@@ -63,7 +58,9 @@
 <div class="flex p-4 @container">
 <div class="flex w-full flex-col gap-4 @[520px]:flex-row @[520px]:justify-between @[520px]:items-center">
 <div class="flex gap-4 items-center">
-<div class="bg-center bg-no-repeat aspect-square bg-cover rounded-full h-20 w-20 border-2 border-primary/20" data-alt="Portrait of a male patient smiling" style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuCRhF6W_Od2b0YzxLsZ4G52qOmymOQAc3_x6i3R1bELOyeVoNhM2mOilzUEWA4xQX4S_silwLOVtvmKgFXklZ4eQhCIpDy9RCWRwywCsKodtprt20LWlebP3BvSuZix8PzU7jkvu3LuKhPplK2AbrQUAq8W15L1QcD_DF0lDMffYS6nFu3Ggj22SdZRZymR7Y4f1UM6R0akhulho3H_SyijlMtt9dAIY94i2lJxr7MUoGOscYkzc14QTXsFR56uC5Uk_PE1TETdof8");'></div>
+<div class="aspect-square h-20 w-20 overflow-hidden rounded-full border-2 border-primary/20">
+<img alt="Juan Pérez sonriendo" class="h-full w-full object-cover" src="https://lh3.googleusercontent.com/aida-public/AB6AXuCRhF6W_Od2b0YzxLsZ4G52qOmymOQAc3_x6i3R1bELOyeVoNhM2mOilzUEWA4xQX4S_silwLOVtvmKgFXklZ4eQhCIpDy9RCWRwywCsKodtprt20LWlebP3BvSuZix8PzU7jkvu3LuKhPplK2AbrQUAq8W15L1QcD_DF0lDMffYS6nFu3Ggj22SdZRZymR7Y4f1UM6R0akhulho3H_SyijlMtt9dAIY94i2lJxr7MUoGOscYkzc14QTXsFR56uC5Uk_PE1TETdof8"/>
+</div>
 <div class="flex flex-col justify-center">
 <p class="text-[#111418] dark:text-white text-xl font-bold leading-tight tracking-[-0.015em]">Juan Pérez</p>
 <p class="text-[#617589] dark:text-gray-400 text-sm font-normal leading-normal">Disfemia Tónica-Clónica</p>
@@ -139,7 +136,7 @@
 <div class="px-4 mt-6">
 <div class="flex justify-between items-end pb-4">
 <h3 class="text-[#111418] dark:text-white text-lg font-bold leading-tight tracking-[-0.015em]">Sesiones Recientes</h3>
-<p class="text-primary text-sm font-bold cursor-pointer">Ver todo</p>
+<a class="text-primary text-sm font-bold" href="index4.html">Ver todo</a>
 </div>
 <div class="flex flex-col gap-3">
 <!-- Recording Item 1 -->
@@ -180,16 +177,27 @@
 <span class="material-symbols-outlined text-xl">edit_note</span>
 <p class="text-sm font-bold uppercase tracking-tight">Nota del Terapeuta</p>
 </div>
-<textarea class="w-full bg-transparent border-none focus:ring-0 text-sm text-[#111418] dark:text-gray-200 placeholder-gray-400 resize-none min-h-[80px]" placeholder="Escribe aquí las tareas para la próxima semana...">Buen progreso esta semana. Para el lunes: Practicar Easy Onset durante 10 minutos al levantarse. Enfocarse en la respiración diafragmática.</textarea>
+<label class="sr-only" for="homework-notes">Nota del terapeuta</label>
+<textarea class="w-full bg-transparent border-none focus:ring-0 text-sm text-[#111418] dark:text-gray-200 placeholder-gray-400 resize-none min-h-[80px]" id="homework-notes" placeholder="Escribe aquí las tareas para la próxima semana...">Buen progreso esta semana. Para el lunes: Practicar Easy Onset durante 10 minutos al levantarse. Enfocarse en la respiración diafragmática.</textarea>
 <div class="flex justify-end mt-2">
-<button class="bg-primary text-white text-xs font-bold py-2 px-4 rounded-lg shadow-sm">Guardar Nota</button>
+<button class="bg-primary text-white text-xs font-bold py-2 px-4 rounded-lg shadow-sm" type="button">Guardar Nota</button>
 </div>
 </div>
 </div>
+<nav class="mb-8 px-4">
+<div class="flex flex-wrap gap-3 text-xs font-bold uppercase tracking-wide text-gray-500">
+<a class="hover:text-primary transition-colors" href="index.html">Inicio</a>
+<a class="hover:text-primary transition-colors" href="index1.html">Shadowing</a>
+<a class="hover:text-primary transition-colors" href="index2.html">Inicio suave</a>
+<a class="hover:text-primary transition-colors" href="index3.html">Prolongación</a>
+<a class="hover:text-primary transition-colors" href="index4.html">Panel</a>
+<a aria-current="page" class="text-primary" href="index5.html">Paciente</a>
+</div>
+</nav>
 <!-- Sticky Bottom CTA (Mobile Style) -->
 <div class="fixed bottom-0 left-0 right-0 max-w-[480px] mx-auto p-4 bg-white/80 dark:bg-[#1a242f]/80 backdrop-blur-md border-t border-gray-100 dark:border-gray-800 flex gap-3">
-<button class="flex-1 bg-white border border-primary text-primary font-bold py-3 rounded-xl text-sm">Agendar Cita</button>
-<button class="flex-1 bg-primary text-white font-bold py-3 rounded-xl text-sm flex items-center justify-center gap-2">
+<button class="flex-1 bg-white border border-primary text-primary font-bold py-3 rounded-xl text-sm" type="button">Agendar Cita</button>
+<button class="flex-1 bg-primary text-white font-bold py-3 rounded-xl text-sm flex items-center justify-center gap-2" type="button">
 <span class="material-symbols-outlined text-lg">add_task</span>
                 Nueva Tarea
             </button>


### PR DESCRIPTION
### Motivation
- Unificar y mejorar la navegación entre las pantallas estáticas `index*.html` para permitir moverse fácilmente entre vistas. 
- Aumentar la accesibilidad añadiendo roles, `aria-` labels y mejorando la semántica de controles interactivos. 
- Normalizar pequeños detalles de estilo y recursos duplicados para evitar inconsistencias visuales entre páginas. 
- Hacer el panel (drawer) accesible y controlable desde teclado para cumplir mejores prácticas de interacción.

### Description
- Añadí navegación entre todas las páginas usando enlaces semánticos (`<a href="indexX.html">`) y menús de navegación en cada página para recorrer `index*.html`.
- Mejoré accesibilidad: conversiones a `button`/`a` con `type` y `aria-label`, `aria-hidden` donde corresponde, `sr-only` labels para `textarea`, y textos `alt` en imágenes. 
- Limpié duplicados de fuentes y consolidé reglas base (un sólo `Material Symbols` link y estilos comunes como `min-height: max(884px, 100dvh)`).
- Implementé un drawer accesible en `index4.html` con botones para abrir/cerrar (`aria-controls`, `aria-expanded`, `data-drawer-close`) y un pequeño script para manejar apertura/cierre y `Escape`.

### Testing
- Levanté un servidor local con `python -m http.server` y el script de Playwright navegó a la página y generó una captura (`artifacts/index.png`), y la ejecución de render headless fue exitosa. 
- Verifiqué que los archivos HTML modificados se cargan y muestran la nueva navegación en la captura renderizada (render estático comprobado). 
- No se ejecutaron pruebas unitarias automatizadas sobre lógica (son cambios estáticos en HTML/CSS). 
- Intentos de instalar dependencias (`npm install`) fallaron por restricciones del registro y no afectaron los cambios HTML estáticos.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960e2974318832d80956426d5c2a814)