### PR TITLE
Move inline styles into shared stylesheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;500;600;700;800&amp;display=swap" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
+<link href="styles.css" rel="stylesheet"/>
 <script id="tailwind-config">
         tailwind.config = {
             darkMode: "class",
@@ -28,20 +29,6 @@
             },
         }
     </script>
-<style>
-        body {
-            font-family: 'Manrope', sans-serif;
-            -webkit-tap-highlight-color: transparent;
-        }
-        .material-symbols-outlined {
-            font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
-        }
-    </style>
-<style>
-    body {
-      min-height: max(884px, 100dvh);
-    }
-  </style>
   </head>
 <body class="bg-background-light dark:bg-background-dark text-[#111418] dark:text-gray-100">
 <!-- TopAppBar -->
@@ -59,7 +46,7 @@
 <main class="max-w-md mx-auto pb-24">
 <!-- HeroSection -->
 <div class="@container px-4 pt-4">
-<div class="flex min-h-[360px] flex-col gap-6 bg-cover bg-center bg-no-repeat rounded-xl items-center justify-center p-6 shadow-sm" data-alt="Abstract calming blue and green waves background" style='background-image: linear-gradient(rgba(19, 127, 236, 0.6) 0%, rgba(19, 127, 236, 0.8) 100%), url("https://lh3.googleusercontent.com/aida-public/AB6AXuDeiGDkpt8HGO7cBEsb_YjoUAmur_5Gye4GIrCpIveluU4zK48oI7PZjEk9V-O5A_fs5T7dVvRpJ0BPj4S4iK65Ft1pXnp-dwqvqf2zmKpzG_SfpfiM3AJdTZplWQxPLBJHSJlGStvIkIf3thOZkXvvGvibZwnmRa1Nes_jKk7CnjRgBb2FpukQkTIH0Y_PrT6hiAelMgS0TFqTpw7sYgmYrrNB0lJhu_cVS2OaDHdomFdeUs_mkurp4rWE_Z9MaiiKFIvVW9Wx7Kw");'>
+<div class="hero-background flex min-h-[360px] flex-col gap-6 bg-cover bg-center bg-no-repeat rounded-xl items-center justify-center p-6 shadow-sm" data-alt="Abstract calming blue and green waves background">
 <div class="flex flex-col gap-2 text-center">
 <h1 class="text-white text-3xl font-black leading-tight tracking-[-0.033em] @[480px]:text-4xl">
                         Entendiendo la Disfemia
@@ -169,7 +156,7 @@
 <!-- iOS style Bottom Navigation Tab Bar (Simulated) -->
 <div class="fixed bottom-0 left-0 right-0 bg-white/90 dark:bg-background-dark/90 backdrop-blur-md border-t border-gray-100 dark:border-gray-800 flex justify-around items-center h-20 pb-4 px-6 z-50">
 <div class="flex flex-col items-center text-primary">
-<span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 1;">home</span>
+<span class="material-symbols-outlined material-symbols-filled">home</span>
 <span class="text-[10px] font-bold mt-1">Inicio</span>
 </div>
 <div class="flex flex-col items-center text-gray-400">

--- a/index1.html
+++ b/index1.html
@@ -8,6 +8,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@200..800&amp;display=swap" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
+<link href="styles.css" rel="stylesheet"/>
 <script id="tailwind-config">
         tailwind.config = {
             darkMode: "class",
@@ -26,19 +27,6 @@
             },
         }
     </script>
-<style>
-        .material-symbols-outlined {
-            font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
-        }
-        body {
-            font-family: 'Manrope', sans-serif;
-        }
-    </style>
-<style>
-    body {
-      min-height: max(884px, 100dvh);
-    }
-  </style>
   </head>
 <body class="bg-background-light dark:bg-background-dark min-h-screen">
 <div class="relative flex h-auto min-h-screen w-full max-w-[430px] mx-auto flex-col bg-background-light dark:bg-background-dark overflow-x-hidden shadow-2xl">

--- a/index2.html
+++ b/index2.html
@@ -6,6 +6,7 @@
 <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
+<link href="styles.css" rel="stylesheet"/>
 <script id="tailwind-config">
         tailwind.config = {
             darkMode: "class",
@@ -26,11 +27,6 @@
         }
     </script>
 <title>Inicio Suave - Logopedia</title>
-<style>
-    body {
-      min-height: max(884px, 100dvh);
-    }
-  </style>
   </head>
 <body class="bg-background-light dark:bg-background-dark font-display text-[#111418] dark:text-white min-h-screen">
 <!-- Top Navigation Bar -->
@@ -75,7 +71,7 @@
 </div>
 <!-- Sentence Generator Card -->
 <div class="px-4 mt-6">
-<div class="relative bg-primary overflow-hidden rounded-xl shadow-lg" data-alt="Deep blue gradient with subtle geometric patterns" style="background-image: linear-gradient(135deg, #137fec 0%, #0b5fb3 100%);">
+<div class="sentence-card-gradient relative bg-primary overflow-hidden rounded-xl shadow-lg" data-alt="Deep blue gradient with subtle geometric patterns">
 <div class="p-6">
 <div class="flex flex-col gap-2 mb-6">
 <span class="text-white/70 text-xs font-bold uppercase tracking-widest">Frase de Práctica</span>

--- a/index3.html
+++ b/index3.html
@@ -7,6 +7,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@200..800&amp;display=swap" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
+<link href="styles.css" rel="stylesheet"/>
 <script id="tailwind-config">
         tailwind.config = {
             darkMode: "class",
@@ -25,17 +26,6 @@
             },
         }
     </script>
-<style>
-        body { font-family: 'Manrope', sans-serif; }
-        .material-symbols-outlined {
-            font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
-        }
-    </style>
-<style>
-    body {
-      min-height: max(884px, 100dvh);
-    }
-  </style>
   </head>
 <body class="bg-background-light dark:bg-background-dark min-h-screen flex flex-col transition-colors duration-300">
 <!-- Top Navigation Bar -->

--- a/index4.html
+++ b/index4.html
@@ -11,6 +11,7 @@
 <!-- Material Symbols Outlined -->
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
+<link href="styles.css" rel="stylesheet"/>
 <script id="tailwind-config">
         tailwind.config = {
             darkMode: "class",
@@ -29,19 +30,6 @@
             },
         }
     </script>
-<style>
-        .material-symbols-outlined {
-            font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
-        }
-        body {
-            font-family: 'Manrope', sans-serif;
-        }
-    </style>
-<style>
-    body {
-      min-height: max(884px, 100dvh);
-    }
-  </style>
   </head>
 <body class="bg-background-light dark:bg-background-dark text-[#111718] dark:text-white min-h-screen">
 <!-- Navigation Drawer (Overlay - Hidden by default in a real app, here shown as part of the structure) -->

--- a/index5.html
+++ b/index5.html
@@ -8,6 +8,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@200;300;400;500;600;700;800&amp;display=swap" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
+<link href="styles.css" rel="stylesheet"/>
 <script id="tailwind-config">
         tailwind.config = {
             darkMode: "class",
@@ -31,19 +32,6 @@
             },
         }
     </script>
-<style>
-        body {
-            font-family: 'Manrope', sans-serif;
-        }
-        .material-symbols-outlined {
-            font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
-        }
-    </style>
-<style>
-    body {
-      min-height: max(884px, 100dvh);
-    }
-  </style>
   </head>
 <body class="bg-background-light dark:bg-background-dark text-[#111418] dark:text-white min-h-screen">
 <div class="max-w-[480px] mx-auto bg-white dark:bg-[#1a242f] min-h-screen shadow-sm">
@@ -63,7 +51,7 @@
 <div class="flex p-4 @container">
 <div class="flex w-full flex-col gap-4 @[520px]:flex-row @[520px]:justify-between @[520px]:items-center">
 <div class="flex gap-4 items-center">
-<div class="bg-center bg-no-repeat aspect-square bg-cover rounded-full h-20 w-20 border-2 border-primary/20" data-alt="Portrait of a male patient smiling" style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuCRhF6W_Od2b0YzxLsZ4G52qOmymOQAc3_x6i3R1bELOyeVoNhM2mOilzUEWA4xQX4S_silwLOVtvmKgFXklZ4eQhCIpDy9RCWRwywCsKodtprt20LWlebP3BvSuZix8PzU7jkvu3LuKhPplK2AbrQUAq8W15L1QcD_DF0lDMffYS6nFu3Ggj22SdZRZymR7Y4f1UM6R0akhulho3H_SyijlMtt9dAIY94i2lJxr7MUoGOscYkzc14QTXsFR56uC5Uk_PE1TETdof8");'></div>
+<div class="profile-avatar-image bg-center bg-no-repeat aspect-square bg-cover rounded-full h-20 w-20 border-2 border-primary/20" data-alt="Portrait of a male patient smiling"></div>
 <div class="flex flex-col justify-center">
 <p class="text-[#111418] dark:text-white text-xl font-bold leading-tight tracking-[-0.015em]">Juan Pérez</p>
 <p class="text-[#617589] dark:text-gray-400 text-sm font-normal leading-normal">Disfemia Tónica-Clónica</p>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,29 @@
+body {
+  font-family: "Manrope", sans-serif;
+  min-height: max(884px, 100dvh);
+  -webkit-tap-highlight-color: transparent;
+}
+
+.material-symbols-outlined {
+  font-variation-settings: "FILL" 0, "wght" 400, "GRAD" 0, "opsz" 24;
+}
+
+.material-symbols-filled {
+  font-variation-settings: "FILL" 1, "wght" 400, "GRAD" 0, "opsz" 24;
+}
+
+.hero-background {
+  background-image: linear-gradient(
+      rgba(19, 127, 236, 0.6) 0%,
+      rgba(19, 127, 236, 0.8) 100%
+    ),
+    url("https://lh3.googleusercontent.com/aida-public/AB6AXuDeiGDkpt8HGO7cBEsb_YjoUAmur_5Gye4GIrCpIveluU4zK48oI7PZjEk9V-O5A_fs5T7dVvRpJ0BPj4S4iK65Ft1pXnp-dwqvqf2zmKpzG_SfpfiM3AJdTZplWQxPLBJHSJlGStvIkIf3thOZkXvvGvibZwnmRa1Nes_jKk7CnjRgBb2FpukQkTIH0Y_PrT6hiAelMgS0TFqTpw7sYgmYrrNB0lJhu_cVS2OaDHdomFdeUs_mkurp4rWE_Z9MaiiKFIvVW9Wx7Kw");
+}
+
+.sentence-card-gradient {
+  background-image: linear-gradient(135deg, #137fec 0%, #0b5fb3 100%);
+}
+
+.profile-avatar-image {
+  background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuCRhF6W_Od2b0YzxLsZ4G52qOmymOQAc3_x6i3R1bELOyeVoNhM2mOilzUEWA4xQX4S_silwLOVtvmKgFXklZ4eQhCIpDy9RCWRwywCsKodtprt20LWlebP3BvSuZix8PzU7jkvu3LuKhPplK2AbrQUAq8W15L1QcD_DF0lDMffYS6nFu3Ggj22SdZRZymR7Y4f1UM6R0akhulho3H_SyijlMtt9dAIY94i2lJxr7MUoGOscYkzc14QTXsFR56uC5Uk_PE1TETdof8");
+}


### PR DESCRIPTION
### Motivation
- Centralizar y aligerar estilos para que los archivos HTML sean más livianos y fáciles de mantener.
- Evitar la repetición de reglas tipográficas y de iconografía en cada página mediante un CSS compartido.
- Convertir fondos e imágenes en clases reutilizables para mejorar la coherencia visual entre páginas.

### Description
- Añadido el archivo `styles.css` con reglas base (`body`, `.material-symbols-outlined`) y nuevas clases reutilizables como `.hero-background`, `.sentence-card-gradient`, `.profile-avatar-image` y `.material-symbols-filled`.
- Enlazado `styles.css` desde `index.html`, `index1.html`, `index2.html`, `index3.html`, `index4.html` y `index5.html`.
- Eliminadas las etiquetas `<style>` en línea y reemplazados los `style="background-image:..."` por las nuevas clases en los HTML afectados.
- Actualizado el icono de inicio para usar la clase `material-symbols-filled` donde correspondía.

### Testing
- No se ejecutaron pruebas automatizadas para estos cambios (modificaciones estáticas de HTML/CSS).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960eeaa5504832dbaf355c1971da3cf)